### PR TITLE
feat(v1.0.0): CLI, Provider Profiles, API Documentation

### DIFF
--- a/docs/advanced/etw_basics.rst
+++ b/docs/advanced/etw_basics.rst
@@ -1,0 +1,164 @@
+ETW Basics
+==========
+
+Event Tracing for Windows (ETW) is a high-performance event logging mechanism built into Windows.
+
+What is ETW?
+------------
+
+ETW provides:
+
+- **Low overhead**: Designed for production systems
+- **Structured events**: Rich event data with schemas
+- **Real-time processing**: Events can be consumed as they occur
+- **File-based logging**: Events can be saved to ETL files
+
+Components
+----------
+
+Providers
+~~~~~~~~~
+
+Providers are components that generate events:
+
+- **Manifest-based providers**: Define events in XML manifest
+- **TraceLogging providers**: Define events at runtime
+- **MOF providers**: Legacy format
+
+Each provider has:
+
+- **GUID**: Unique identifier
+- **Name**: Human-readable name
+- **Events**: Set of defined events
+- **Keywords**: Event categories
+- **Levels**: Event severity
+
+Sessions
+~~~~~~~~
+
+Sessions (also called traces) collect events:
+
+- Control which providers are enabled
+- Set buffer sizes and other parameters
+- Direct events to files or real-time consumers
+
+Consumers
+~~~~~~~~~
+
+Consumers receive and process events:
+
+- **Real-time**: Process events as they occur
+- **File-based**: Read from ETL files
+
+Trace Levels
+------------
+
+Events have severity levels:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Level
+     - Value
+     - Description
+   * - Critical
+     - 1
+     - Critical errors
+   * - Error
+     - 2
+     - Error conditions
+   * - Warning
+     - 3
+     - Warning conditions
+   * - Information
+     - 4
+     - Informational messages
+   * - Verbose
+     - 5
+     - Detailed debug information
+
+Keywords
+--------
+
+Keywords are bit flags that categorize events:
+
+.. code-block:: python
+
+   # Enable all keywords
+   provider = EtwProvider("guid", "name")
+   provider = provider.with_keywords(0xFFFFFFFFFFFFFFFF)
+
+   # Enable specific keywords
+   provider = provider.with_keywords(0x0000000000000010)
+
+Common Providers
+----------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Provider
+     - Description
+   * - Microsoft-Windows-Kernel-Process
+     - Process creation/termination
+   * - Microsoft-Windows-Kernel-File
+     - File I/O operations
+   * - Microsoft-Windows-Kernel-Network
+     - Network operations
+   * - Microsoft-Windows-DNS-Client
+     - DNS queries
+   * - Microsoft-Windows-TCPIP
+     - TCP/IP stack events
+   * - Microsoft-Windows-Security-Auditing
+     - Security events
+
+Finding Providers
+-----------------
+
+Use ``logman`` to list providers:
+
+.. code-block:: bash
+
+   logman query providers
+
+Or use PyETWkit:
+
+.. code-block:: python
+
+   from pyetwkit import list_providers, search_providers
+
+   # List all
+   providers = list_providers()
+
+   # Search
+   results = search_providers("Kernel")
+
+ETL Files
+---------
+
+ETL (Event Trace Log) files store captured events:
+
+.. code-block:: bash
+
+   # Start trace to file
+   logman start mytrace -p Microsoft-Windows-DNS-Client -o trace.etl -ets
+
+   # Stop trace
+   logman stop mytrace -ets
+
+Read with PyETWkit:
+
+.. code-block:: python
+
+   from pyetwkit import EtlReader
+
+   with EtlReader("trace.etl") as reader:
+       for event in reader:
+           print(event)
+
+Resources
+---------
+
+- `ETW Documentation <https://docs.microsoft.com/en-us/windows/win32/etw/event-tracing-portal>`_
+- `Providers Reference <https://docs.microsoft.com/en-us/windows/win32/etw/event-tracing-reference>`_
+- `Performance Toolkit <https://docs.microsoft.com/en-us/windows-hardware/test/wpt/>`_

--- a/docs/advanced/low_level.rst
+++ b/docs/advanced/low_level.rst
@@ -1,0 +1,150 @@
+Low-Level API
+=============
+
+PyETWkit provides low-level access to ETW functionality for advanced use cases.
+
+Direct Session Control
+----------------------
+
+.. code-block:: python
+
+   from pyetwkit._core import EtwSession, EtwProvider
+
+   # Create session
+   session = EtwSession("MySession")
+
+   # Add provider with specific settings
+   provider = EtwProvider("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716", "Kernel-Process")
+   provider = provider.with_level(5)  # Verbose
+   provider = provider.with_keywords(0xFFFFFFFFFFFFFFFF)
+   session.add_provider(provider)
+
+   # Start session
+   session.start()
+
+   # Process events
+   try:
+       while True:
+           event = session.next_event_timeout(1000)
+           if event:
+               print(f"Event: {event.event_id}")
+   except KeyboardInterrupt:
+       pass
+   finally:
+       session.stop()
+
+Provider Discovery
+------------------
+
+.. code-block:: python
+
+   from pyetwkit._core import list_providers, search_providers, get_provider_info
+
+   # List all providers
+   providers = list_providers()
+   print(f"Total: {len(providers)}")
+
+   # Search
+   results = search_providers("Audio")
+
+   # Get details
+   info = get_provider_info("Microsoft-Windows-Audio")
+   print(f"GUID: {info.guid}")
+
+ETL File Reading
+----------------
+
+.. code-block:: python
+
+   from pyetwkit._core import EtlReader
+
+   # Read ETL file
+   with EtlReader("trace.etl") as reader:
+       for event in reader:
+           print(f"{event.provider_id}: {event.event_id}")
+
+   # Read all events
+   reader = EtlReader("trace.etl")
+   events = reader.read_all()
+
+Event Properties
+----------------
+
+.. code-block:: python
+
+   # Event attributes
+   event.provider_id      # Provider GUID
+   event.provider_name    # Provider name (if known)
+   event.event_id         # Event ID
+   event.version          # Event version
+   event.level            # Trace level
+   event.opcode           # Opcode
+   event.keyword          # Keywords
+   event.timestamp        # Event timestamp
+   event.process_id       # Process ID
+   event.thread_id        # Thread ID
+   event.properties       # Event properties dict
+
+   # Convert to dict
+   event_dict = event.to_dict()
+
+Stack Trace Support
+-------------------
+
+Enable stack trace capture:
+
+.. code-block:: python
+
+   from pyetwkit._core import EtwProvider, EnableProperty
+
+   provider = EtwProvider("guid", "name")
+   provider = provider.with_enable_property(EnableProperty.STACK_TRACE)
+
+   # Access stack trace
+   for event in listener:
+       if event.stack_trace:
+           for addr in event.stack_trace:
+               print(f"  0x{addr:016x}")
+
+Kernel Sessions
+---------------
+
+For kernel-level monitoring:
+
+.. code-block:: python
+
+   from pyetwkit._core import KernelSession, KernelFlags
+
+   session = KernelSession()
+   session.enable_flags(KernelFlags.PROCESS | KernelFlags.THREAD)
+   session.start()
+
+   # Process events
+   for event in session:
+       print(event)
+
+Schema Information
+------------------
+
+.. code-block:: python
+
+   from pyetwkit._core import SchemaCache, EventSchema
+
+   cache = SchemaCache()
+
+   # Get schema for event
+   schema = cache.get_schema(provider_id, event_id, version)
+   if schema:
+       print(f"Event: {schema.event_name}")
+       for prop in schema.properties:
+           print(f"  {prop.name}: {prop.property_type}")
+
+Session Statistics
+------------------
+
+.. code-block:: python
+
+   stats = session.stats()
+   print(f"Events received: {stats.events_received}")
+   print(f"Events lost: {stats.events_lost}")
+   print(f"Buffers processed: {stats.buffers_processed}")

--- a/docs/api/export.rst
+++ b/docs/api/export.rst
@@ -1,0 +1,170 @@
+Data Export
+===========
+
+PyETWkit provides functions to export captured events to various formats.
+
+.. module:: pyetwkit.export
+   :synopsis: Event data export utilities
+
+Functions
+---------
+
+to_dataframe
+~~~~~~~~~~~~
+
+Convert events to a Pandas DataFrame:
+
+.. code-block:: python
+
+   from pyetwkit.export import to_dataframe
+
+   df = to_dataframe(events)
+   print(df.head())
+
+   # Flatten nested properties
+   df = to_dataframe(events, flatten=True)
+
+to_parquet
+~~~~~~~~~~
+
+Export events to Parquet format (requires pyarrow):
+
+.. code-block:: python
+
+   from pyetwkit.export import to_parquet
+
+   to_parquet(events, "events.parquet")
+
+   # With compression
+   to_parquet(events, "events.parquet", compression="snappy")
+
+to_arrow
+~~~~~~~~
+
+Convert events to Arrow Table (requires pyarrow):
+
+.. code-block:: python
+
+   from pyetwkit.export import to_arrow
+
+   table = to_arrow(events)
+   print(table.schema)
+
+to_csv
+~~~~~~
+
+Export events to CSV:
+
+.. code-block:: python
+
+   from pyetwkit.export import to_csv
+
+   to_csv(events, "events.csv")
+
+to_json
+~~~~~~~
+
+Export events to JSON:
+
+.. code-block:: python
+
+   from pyetwkit.export import to_json
+
+   # To file
+   to_json(events, "events.json")
+
+   # With indentation
+   to_json(events, "events.json", indent=2)
+
+   # To string
+   json_str = to_json(events)
+
+to_jsonl
+~~~~~~~~
+
+Export events to JSON Lines (one JSON object per line):
+
+.. code-block:: python
+
+   from pyetwkit.export import to_jsonl
+
+   to_jsonl(events, "events.jsonl")
+
+API Reference
+-------------
+
+.. autofunction:: pyetwkit.export.to_dataframe
+
+.. autofunction:: pyetwkit.export.to_parquet
+
+.. autofunction:: pyetwkit.export.to_arrow
+
+.. autofunction:: pyetwkit.export.to_csv
+
+.. autofunction:: pyetwkit.export.to_json
+
+.. autofunction:: pyetwkit.export.to_jsonl
+
+Examples
+--------
+
+Capture and Export
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+   from pyetwkit.export import to_dataframe, to_parquet
+
+   # Capture events
+   with EtwListener("Microsoft-Windows-DNS-Client") as listener:
+       events = list(listener.events(max_events=1000))
+
+   # To DataFrame for analysis
+   df = to_dataframe(events)
+   print(df.describe())
+
+   # Save for later
+   to_parquet(events, "dns_events.parquet")
+
+Streaming Export
+~~~~~~~~~~~~~~~~
+
+For large event streams, use JSON Lines:
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+   from pyetwkit.export import to_jsonl
+
+   with EtwListener("Microsoft-Windows-Kernel-Process") as listener:
+       # Batch export
+       batch = []
+       batch_num = 0
+
+       for event in listener:
+           batch.append(event)
+
+           if len(batch) >= 10000:
+               to_jsonl(batch, f"events_{batch_num}.jsonl")
+               batch = []
+               batch_num += 1
+
+Analysis with Pandas
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from pyetwkit.export import to_dataframe
+
+   df = to_dataframe(events)
+
+   # Filter by event ID
+   process_start = df[df["event_id"] == 1]
+
+   # Group by provider
+   by_provider = df.groupby("provider_name").size()
+
+   # Time-based analysis
+   df["timestamp"] = pd.to_datetime(df["timestamp"])
+   events_per_second = df.resample("1s", on="timestamp").size()

--- a/docs/api/listener.rst
+++ b/docs/api/listener.rst
@@ -1,0 +1,97 @@
+EtwListener
+===========
+
+The ``EtwListener`` class provides synchronous ETW event monitoring.
+
+.. module:: pyetwkit.listener
+   :synopsis: Synchronous ETW event listener
+
+Basic Usage
+-----------
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+
+   with EtwListener("Microsoft-Windows-DNS-Client") as listener:
+       for event in listener:
+           print(event)
+
+Class Reference
+---------------
+
+.. autoclass:: pyetwkit.listener.EtwListener
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Configuration
+-------------
+
+Level
+~~~~~
+
+Set the trace level:
+
+.. code-block:: python
+
+   # Level can be: critical, error, warning, information, verbose
+   listener = EtwListener("provider", level="verbose")
+
+Keywords
+~~~~~~~~
+
+Filter events by keywords:
+
+.. code-block:: python
+
+   listener = EtwListener("provider", keywords=0xFFFFFFFFFFFFFFFF)
+
+Multiple Providers
+~~~~~~~~~~~~~~~~~~
+
+Monitor multiple providers:
+
+.. code-block:: python
+
+   providers = [
+       "Microsoft-Windows-Kernel-Process",
+       "Microsoft-Windows-Kernel-File",
+   ]
+   listener = EtwListener(providers)
+
+Using Profiles
+~~~~~~~~~~~~~~
+
+Use a pre-defined profile:
+
+.. code-block:: python
+
+   listener = EtwListener(profile="audio")
+
+Examples
+--------
+
+Process Monitoring
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+
+   with EtwListener("Microsoft-Windows-Kernel-Process") as listener:
+       for event in listener:
+           print(f"Process event: {event.event_id}")
+           if event.properties.get("ImageFileName"):
+               print(f"  Image: {event.properties['ImageFileName']}")
+
+Statistics
+~~~~~~~~~~
+
+.. code-block:: python
+
+   with EtwListener("provider") as listener:
+       for event in listener:
+           stats = listener.stats()
+           print(f"Received: {stats.events_received}")
+           print(f"Dropped: {stats.events_lost}")

--- a/docs/api/profiles.rst
+++ b/docs/api/profiles.rst
@@ -1,0 +1,122 @@
+Profiles Module
+===============
+
+The profiles module provides pre-configured provider sets for common use cases.
+
+.. module:: pyetwkit.profiles
+   :synopsis: Provider profile management
+
+Classes
+-------
+
+Profile
+~~~~~~~
+
+.. autoclass:: pyetwkit.profiles.Profile
+   :members:
+   :undoc-members:
+
+ProviderConfig
+~~~~~~~~~~~~~~
+
+.. autoclass:: pyetwkit.profiles.ProviderConfig
+   :members:
+   :undoc-members:
+
+Functions
+---------
+
+get_profile
+~~~~~~~~~~~
+
+.. autofunction:: pyetwkit.profiles.get_profile
+
+list_profiles
+~~~~~~~~~~~~~
+
+.. autofunction:: pyetwkit.profiles.list_profiles
+
+load_profile
+~~~~~~~~~~~~
+
+.. autofunction:: pyetwkit.profiles.load_profile
+
+register_profile
+~~~~~~~~~~~~~~~~
+
+.. autofunction:: pyetwkit.profiles.register_profile
+
+Usage Examples
+--------------
+
+Getting a Profile
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from pyetwkit.profiles import get_profile
+
+   audio = get_profile("audio")
+   print(f"Name: {audio.name}")
+   print(f"Description: {audio.description}")
+   for p in audio.providers:
+       print(f"  - {p.name} ({p.level})")
+
+Listing Profiles
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from pyetwkit.profiles import list_profiles
+
+   for profile in list_profiles():
+       print(f"{profile.name}: {profile.description}")
+
+Creating Custom Profiles
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+From code:
+
+.. code-block:: python
+
+   from pyetwkit.profiles import Profile, ProviderConfig, register_profile
+
+   custom = Profile(
+       name="my_custom",
+       description="My custom profile",
+       providers=[
+           ProviderConfig(
+               name="Microsoft-Windows-DNS-Client",
+               level="verbose",
+           ),
+           ProviderConfig(
+               name="Microsoft-Windows-TCPIP",
+               level="information",
+               keywords=0xFFFFFFFF,
+           ),
+       ],
+   )
+   register_profile(custom)
+
+From YAML file:
+
+.. code-block:: python
+
+   from pyetwkit.profiles import load_profile
+
+   profile = load_profile("my_profile.yaml")
+
+YAML Profile Format
+-------------------
+
+.. code-block:: yaml
+
+   name: my_profile
+   description: Description of the profile
+   providers:
+     - name: Microsoft-Windows-Provider-Name
+       guid: optional-guid-if-needed
+       level: verbose  # critical, error, warning, information, verbose
+       keywords: 0xFFFFFFFFFFFFFFFF  # optional keyword filter
+     - name: Another-Provider
+       level: information

--- a/docs/api/streamer.rst
+++ b/docs/api/streamer.rst
@@ -1,0 +1,118 @@
+EtwStreamer
+===========
+
+The ``EtwStreamer`` class provides asynchronous ETW event monitoring.
+
+.. module:: pyetwkit.streamer
+   :synopsis: Asynchronous ETW event streamer
+
+Basic Usage
+-----------
+
+.. code-block:: python
+
+   import asyncio
+   from pyetwkit import EtwStreamer
+
+   async def monitor():
+       async with EtwStreamer("Microsoft-Windows-DNS-Client") as streamer:
+           async for event in streamer:
+               print(event)
+
+   asyncio.run(monitor())
+
+Class Reference
+---------------
+
+.. autoclass:: pyetwkit.streamer.EtwStreamer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Async Iteration
+---------------
+
+``EtwStreamer`` supports async iteration:
+
+.. code-block:: python
+
+   async with EtwStreamer("provider") as streamer:
+       async for event in streamer:
+           await process_event(event)
+
+Event Methods
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   # Get next event with timeout
+   event = await streamer.next_event(timeout=1.0)
+
+   # Try to get event without waiting
+   event = streamer.try_next_event()
+
+Multiple Providers
+------------------
+
+.. code-block:: python
+
+   providers = [
+       "Microsoft-Windows-Kernel-Process",
+       "Microsoft-Windows-Kernel-File",
+   ]
+
+   async with EtwStreamer(providers) as streamer:
+       async for event in streamer:
+           print(f"{event.provider_name}: {event.event_id}")
+
+Using Profiles
+--------------
+
+.. code-block:: python
+
+   async with EtwStreamer(profile="network") as streamer:
+       async for event in streamer:
+           print(event)
+
+Examples
+--------
+
+Async Processing
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   import asyncio
+   from pyetwkit import EtwStreamer
+
+   async def process_events():
+       async with EtwStreamer("Microsoft-Windows-DNS-Client") as streamer:
+           async for event in streamer:
+               # Async processing
+               await save_to_database(event)
+
+               if streamer.stats().events_received >= 100:
+                   break
+
+   asyncio.run(process_events())
+
+Concurrent Monitoring
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   import asyncio
+   from pyetwkit import EtwStreamer
+
+   async def monitor(profile: str):
+       async with EtwStreamer(profile=profile) as streamer:
+           async for event in streamer:
+               print(f"[{profile}] {event.event_id}")
+
+   async def main():
+       await asyncio.gather(
+           monitor("network"),
+           monitor("process"),
+       )
+
+   asyncio.run(main())

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,150 @@
+Command Line Interface
+======================
+
+PyETWkit includes a command-line interface for quick ETW monitoring.
+
+Installation
+------------
+
+The CLI is installed automatically with PyETWkit:
+
+.. code-block:: bash
+
+   pip install pyetwkit
+
+Usage
+-----
+
+.. code-block:: bash
+
+   pyetwkit --help
+
+Commands
+--------
+
+providers
+~~~~~~~~~
+
+List available ETW providers on the system.
+
+.. code-block:: bash
+
+   # List all providers (limited to 50 by default)
+   pyetwkit providers
+
+   # Search for providers
+   pyetwkit providers --search Kernel
+
+   # Show more providers
+   pyetwkit providers --limit 100
+
+   # JSON output
+   pyetwkit providers --format json
+
+profiles
+~~~~~~~~
+
+List available provider profiles.
+
+.. code-block:: bash
+
+   # List profiles
+   pyetwkit profiles
+
+   # JSON output
+   pyetwkit profiles --format json
+
+listen
+~~~~~~
+
+Monitor ETW events from a provider or profile.
+
+.. note::
+   This command requires administrator privileges.
+
+.. code-block:: bash
+
+   # Listen to a specific provider
+   pyetwkit listen Microsoft-Windows-Kernel-Process
+
+   # Use a profile
+   pyetwkit listen --profile audio
+
+   # Specify output format
+   pyetwkit listen --profile network --format json
+
+   # Save to file
+   pyetwkit listen --profile network --output events.jsonl --format jsonl
+
+   # Limit events
+   pyetwkit listen Microsoft-Windows-DNS-Client --max-events 100
+
+   # Set trace level
+   pyetwkit listen --profile network --level verbose
+
+Options
+^^^^^^^
+
+``PROVIDER``
+    ETW provider name or GUID to monitor.
+
+``--profile, -p``
+    Use a provider profile instead of specifying a provider.
+
+``--format, -f``
+    Output format: ``table``, ``json``, or ``jsonl``. Default: ``table``.
+
+``--output, -o``
+    Output file path. If not specified, prints to stdout.
+
+``--max-events, -n``
+    Maximum number of events to capture.
+
+``--level, -l``
+    Trace level: ``critical``, ``error``, ``warning``, ``info``, ``verbose``.
+    Default: ``info``.
+
+Examples
+--------
+
+Provider Discovery
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Find audio-related providers
+   pyetwkit providers --search Audio
+
+   # Find process-related providers
+   pyetwkit providers --search "Kernel-Process"
+
+   # Export provider list to JSON
+   pyetwkit providers --format json > providers.json
+
+Quick Monitoring
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Monitor DNS queries (requires admin)
+   pyetwkit listen Microsoft-Windows-DNS-Client
+
+   # Monitor network with profile (requires admin)
+   pyetwkit listen --profile network
+
+Recording Events
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Record events to JSON Lines file
+   pyetwkit listen --profile network --output events.jsonl --format jsonl
+
+   # Record limited events
+   pyetwkit listen Microsoft-Windows-DNS-Client --max-events 1000 --output dns.jsonl --format jsonl
+
+Exit Codes
+----------
+
+- ``0``: Success
+- ``1``: Error (invalid arguments, missing admin privileges, etc.)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,85 @@
+"""Sphinx configuration for PyETWkit documentation."""
+
+import sys
+from pathlib import Path
+
+# Add project source to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+# Project information
+project = "PyETWkit"
+copyright = "2025, m96-chan"
+author = "m96-chan"
+
+# Get version from package
+try:
+    from pyetwkit import __version__
+
+    release = __version__
+except ImportError:
+    release = "1.0.0"
+
+version = release
+
+# Extensions
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "sphinx_autodoc_typehints",
+    "myst_parser",
+]
+
+# Templates path
+templates_path = ["_templates"]
+
+# Exclude patterns
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# HTML theme
+html_theme = "sphinx_rtd_theme"
+
+# HTML static files path
+html_static_path = ["_static"]
+
+# Create _static directory if it doesn't exist
+Path(__file__).parent.joinpath("_static").mkdir(exist_ok=True)
+
+# Intersphinx mapping
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "pandas": ("https://pandas.pydata.org/docs", None),
+}
+
+# Autodoc settings
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "special-members": "__init__",
+    "undoc-members": True,
+    "exclude-members": "__weakref__",
+}
+
+autodoc_typehints = "description"
+autodoc_type_aliases = {}
+
+# Napoleon settings
+napoleon_google_docstyle = True
+napoleon_numpy_docstyle = True
+napoleon_include_init_with_doc = True
+
+# MyST settings
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+]
+
+# Source suffix
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+# Master document
+master_doc = "index"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,101 @@
+PyETWkit Documentation
+======================
+
+**PyETWkit** is a high-performance ETW (Event Tracing for Windows) consumer library for Python,
+built with Rust for maximum performance.
+
+.. note::
+   ETW sessions require administrator privileges on Windows.
+
+Features
+--------
+
+- **High Performance**: Rust-based core for low-latency event processing
+- **Pythonic API**: Clean, easy-to-use Python interface
+- **Async Support**: Native asyncio integration with ``EtwStreamer``
+- **Provider Profiles**: Pre-configured profiles for common use cases
+- **CLI Tool**: Command-line interface for quick monitoring
+- **Data Export**: Export to Parquet, Arrow, Pandas, CSV, JSON
+
+Quick Start
+-----------
+
+Installation
+~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   pip install pyetwkit
+
+Basic Usage
+~~~~~~~~~~~
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+
+   # Listen to process events
+   with EtwListener("Microsoft-Windows-Kernel-Process") as listener:
+       for event in listener:
+           print(f"Event: {event.event_id}")
+
+Using Profiles
+~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+
+   # Use a pre-defined profile
+   with EtwListener(profile="audio") as listener:
+       for event in listener:
+           print(event)
+
+CLI Usage
+~~~~~~~~~
+
+.. code-block:: bash
+
+   # List providers
+   pyetwkit providers --search Kernel
+
+   # List profiles
+   pyetwkit profiles
+
+   # Monitor events (requires admin)
+   pyetwkit listen Microsoft-Windows-Kernel-Process
+
+Documentation
+-------------
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   quickstart
+   tutorial
+   profiles
+   cli
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   api/listener
+   api/streamer
+   api/export
+   api/profiles
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Advanced
+
+   advanced/low_level
+   advanced/etw_basics
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -1,0 +1,181 @@
+Provider Profiles
+=================
+
+PyETWkit includes pre-configured provider profiles for common monitoring scenarios.
+
+Built-in Profiles
+-----------------
+
+audio
+~~~~~
+
+Audio-related providers for monitoring WASAPI, Media Foundation, and MMCSS.
+
+**Providers:**
+
+- Microsoft-Windows-Audio
+- Microsoft-Windows-MediaFoundation-Platform
+- Microsoft-Windows-MMCSS
+
+**Use cases:**
+
+- Audio latency debugging
+- Media playback issues
+- Audio device problems
+
+.. code-block:: python
+
+   with EtwListener(profile="audio") as listener:
+       for event in listener:
+           print(event)
+
+network
+~~~~~~~
+
+Network-related providers for TCP/IP, DNS, and NDIS monitoring.
+
+**Providers:**
+
+- Microsoft-Windows-TCPIP
+- Microsoft-Windows-DNS-Client
+- Microsoft-Windows-NDIS
+
+**Use cases:**
+
+- Network connectivity issues
+- DNS resolution problems
+- Network performance analysis
+
+gpu
+~~~
+
+GPU-related providers for DXGI, D3D, and DWM monitoring.
+
+**Providers:**
+
+- Microsoft-Windows-DXGI
+- Microsoft-Windows-D3D9
+- Microsoft-Windows-Dwm-Core
+
+**Use cases:**
+
+- GPU performance issues
+- Display problems
+- Graphics debugging
+
+process
+~~~~~~~
+
+Process-related providers for monitoring process creation and termination.
+
+**Providers:**
+
+- Microsoft-Windows-Kernel-Process
+
+**Use cases:**
+
+- Process monitoring
+- Security analysis
+- Performance profiling
+
+file
+~~~~
+
+File I/O related providers.
+
+**Providers:**
+
+- Microsoft-Windows-Kernel-File
+
+**Use cases:**
+
+- File access monitoring
+- I/O performance analysis
+
+security
+~~~~~~~~
+
+Security-related providers.
+
+**Providers:**
+
+- Microsoft-Windows-Security-Auditing
+
+**Use cases:**
+
+- Security monitoring
+- Audit logging
+
+powershell
+~~~~~~~~~~
+
+PowerShell-related providers.
+
+**Providers:**
+
+- Microsoft-Windows-PowerShell
+
+**Use cases:**
+
+- Script monitoring
+- PowerShell debugging
+
+Custom Profiles
+---------------
+
+You can create custom profiles using YAML:
+
+.. code-block:: yaml
+
+   # my_profile.yaml
+   name: my_profile
+   description: My custom monitoring profile
+   providers:
+     - name: Microsoft-Windows-DNS-Client
+       level: verbose
+       keywords: 0xFFFFFFFFFFFFFFFF
+     - name: Microsoft-Windows-TCPIP
+       level: information
+
+Load and use:
+
+.. code-block:: python
+
+   from pyetwkit.profiles import load_profile
+
+   profile = load_profile("my_profile.yaml")
+
+   with EtwListener(profile=profile.name) as listener:
+       for event in listener:
+           print(event)
+
+Profile API
+-----------
+
+.. code-block:: python
+
+   from pyetwkit.profiles import (
+       get_profile,
+       list_profiles,
+       load_profile,
+       register_profile,
+       Profile,
+       ProviderConfig,
+   )
+
+   # Get a profile
+   audio = get_profile("audio")
+
+   # List all profiles
+   for profile in list_profiles():
+       print(f"{profile.name}: {profile.description}")
+
+   # Create programmatically
+   custom = Profile(
+       name="custom",
+       description="Custom profile",
+       providers=[
+           ProviderConfig(name="Microsoft-Windows-DNS-Client"),
+       ]
+   )
+   register_profile(custom)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,159 @@
+Quick Start Guide
+=================
+
+This guide will help you get started with PyETWkit.
+
+Prerequisites
+-------------
+
+- Windows 10/11 or Windows Server 2016+
+- Python 3.9+
+- Administrator privileges (for starting ETW sessions)
+
+Installation
+------------
+
+Install from PyPI:
+
+.. code-block:: bash
+
+   pip install pyetwkit
+
+Verify installation:
+
+.. code-block:: python
+
+   import pyetwkit
+   print(pyetwkit.__version__)
+
+Basic Usage
+-----------
+
+Listing Providers
+~~~~~~~~~~~~~~~~~
+
+Before monitoring events, you can list available providers:
+
+.. code-block:: python
+
+   from pyetwkit import list_providers, search_providers
+
+   # List all providers
+   providers = list_providers()
+   print(f"Found {len(providers)} providers")
+
+   # Search for specific providers
+   kernel_providers = search_providers("Kernel")
+   for p in kernel_providers[:5]:
+       print(f"{p.name}: {p.guid}")
+
+Monitoring Events
+~~~~~~~~~~~~~~~~~
+
+Use ``EtwListener`` to monitor events from a provider:
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+
+   # Requires administrator privileges
+   with EtwListener("Microsoft-Windows-Kernel-Process") as listener:
+       for event in listener:
+           print(f"Provider: {event.provider_name}")
+           print(f"Event ID: {event.event_id}")
+           print(f"Properties: {event.properties}")
+
+           # Limit to 10 events for demo
+           if listener.stats().events_received >= 10:
+               break
+
+Using Profiles
+~~~~~~~~~~~~~~
+
+Profiles provide pre-configured sets of providers for common use cases:
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+   from pyetwkit.profiles import list_profiles
+
+   # List available profiles
+   for profile in list_profiles():
+       print(f"{profile.name}: {profile.description}")
+
+   # Use a profile
+   with EtwListener(profile="network") as listener:
+       for event in listener:
+           print(event)
+
+Async Support
+~~~~~~~~~~~~~
+
+For async applications, use ``EtwStreamer``:
+
+.. code-block:: python
+
+   import asyncio
+   from pyetwkit import EtwStreamer
+
+   async def monitor_events():
+       async with EtwStreamer("Microsoft-Windows-DNS-Client") as streamer:
+           async for event in streamer:
+               print(f"Event: {event.event_id}")
+
+   asyncio.run(monitor_events())
+
+Data Export
+~~~~~~~~~~~
+
+Export events to various formats:
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+   from pyetwkit.export import to_dataframe, to_parquet, to_json
+
+   with EtwListener("Microsoft-Windows-DNS-Client") as listener:
+       events = list(listener.events(max_events=100))
+
+   # To Pandas DataFrame
+   df = to_dataframe(events)
+   print(df.head())
+
+   # To Parquet
+   to_parquet(events, "events.parquet")
+
+   # To JSON
+   to_json(events, "events.json")
+
+CLI Usage
+---------
+
+PyETWkit includes a command-line interface:
+
+.. code-block:: bash
+
+   # List providers
+   pyetwkit providers
+
+   # Search providers
+   pyetwkit providers --search Audio
+
+   # List profiles
+   pyetwkit profiles
+
+   # Monitor events (requires admin)
+   pyetwkit listen Microsoft-Windows-Kernel-Process
+
+   # Use a profile
+   pyetwkit listen --profile network
+
+   # Output to file
+   pyetwkit listen --profile network --output events.jsonl --format jsonl
+
+Next Steps
+----------
+
+- See :doc:`tutorial` for more detailed examples
+- Check :doc:`profiles` for available profiles
+- Read :doc:`api/listener` for API reference

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,0 +1,210 @@
+Tutorial
+========
+
+This tutorial covers common use cases for PyETWkit.
+
+Provider Discovery
+------------------
+
+Finding the right ETW provider is the first step:
+
+.. code-block:: python
+
+   from pyetwkit import list_providers, search_providers, get_provider_info
+
+   # List all registered providers
+   all_providers = list_providers()
+   print(f"Total providers: {len(all_providers)}")
+
+   # Search by keyword
+   audio_providers = search_providers("Audio")
+   for p in audio_providers:
+       print(f"  {p.name}")
+
+   # Get detailed info
+   info = get_provider_info("Microsoft-Windows-Kernel-Process")
+   print(f"Name: {info.name}")
+   print(f"GUID: {info.guid}")
+
+Event Monitoring
+----------------
+
+Basic Monitoring
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+
+   with EtwListener("Microsoft-Windows-DNS-Client") as listener:
+       for event in listener:
+           print(f"[{event.timestamp}] Event {event.event_id}")
+           print(f"  Properties: {event.properties}")
+
+           if listener.stats().events_received >= 10:
+               break
+
+Multiple Providers
+~~~~~~~~~~~~~~~~~~
+
+Monitor multiple providers simultaneously:
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+
+   providers = [
+       "Microsoft-Windows-Kernel-Process",
+       "Microsoft-Windows-Kernel-File",
+   ]
+
+   with EtwListener(providers) as listener:
+       for event in listener:
+           print(f"{event.provider_name}: {event.event_id}")
+
+Event Filtering
+~~~~~~~~~~~~~~~
+
+Filter events by various criteria:
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener, EventFilter
+
+   # Filter by process ID
+   filter = EventFilter().process_id(1234)
+
+   with EtwListener("Microsoft-Windows-Kernel-Process", filter=filter) as listener:
+       for event in listener:
+           print(event)
+
+Using Profiles
+--------------
+
+Profiles provide curated sets of providers:
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+   from pyetwkit.profiles import get_profile
+
+   # Check what's in a profile
+   audio = get_profile("audio")
+   print(f"Profile: {audio.name}")
+   print(f"Description: {audio.description}")
+   for p in audio.providers:
+       print(f"  - {p.name}")
+
+   # Use the profile
+   with EtwListener(profile="audio") as listener:
+       for event in listener:
+           print(event)
+
+Custom Profiles
+~~~~~~~~~~~~~~~
+
+Create your own profiles:
+
+.. code-block:: python
+
+   from pyetwkit.profiles import Profile, ProviderConfig, load_profile
+
+   # From code
+   custom = Profile(
+       name="my_profile",
+       description="My custom profile",
+       providers=[
+           ProviderConfig(name="Microsoft-Windows-DNS-Client"),
+           ProviderConfig(name="Microsoft-Windows-TCPIP"),
+       ]
+   )
+
+   # From YAML file
+   profile = load_profile("my_profile.yaml")
+
+Example YAML profile:
+
+.. code-block:: yaml
+
+   name: my_profile
+   description: My custom profile
+   providers:
+     - name: Microsoft-Windows-DNS-Client
+       level: verbose
+     - name: Microsoft-Windows-TCPIP
+       level: information
+       keywords: 0xFFFFFFFF
+
+Data Export
+-----------
+
+Export captured events for analysis:
+
+.. code-block:: python
+
+   from pyetwkit import EtwListener
+   from pyetwkit.export import (
+       to_dataframe,
+       to_parquet,
+       to_csv,
+       to_json,
+       to_jsonl,
+   )
+
+   # Capture events
+   with EtwListener("Microsoft-Windows-DNS-Client") as listener:
+       events = list(listener.events(max_events=100))
+
+   # To Pandas DataFrame
+   df = to_dataframe(events)
+   print(df.info())
+
+   # To Parquet (efficient for large datasets)
+   to_parquet(events, "events.parquet")
+
+   # To CSV
+   to_csv(events, "events.csv")
+
+   # To JSON
+   to_json(events, "events.json", indent=2)
+
+   # To JSON Lines (streaming friendly)
+   to_jsonl(events, "events.jsonl")
+
+Async Programming
+-----------------
+
+For async applications:
+
+.. code-block:: python
+
+   import asyncio
+   from pyetwkit import EtwStreamer
+
+   async def monitor():
+       async with EtwStreamer("Microsoft-Windows-DNS-Client") as streamer:
+           async for event in streamer:
+               print(f"Event: {event.event_id}")
+
+               # Stop after 10 events
+               if streamer.stats().events_received >= 10:
+                   break
+
+   asyncio.run(monitor())
+
+ETL File Processing
+-------------------
+
+Read events from ETL files:
+
+.. code-block:: python
+
+   from pyetwkit import EtlReader
+
+   with EtlReader("trace.etl") as reader:
+       for event in reader:
+           print(f"{event.provider_name}: {event.event_id}")
+
+   # Or read all at once
+   events = reader.read_all()
+   print(f"Read {len(events)} events")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyetwkit"
-version = "0.1.0"
+version = "1.0.0"
 description = "High-performance ETW (Event Tracing for Windows) consumer library for Python"
 readme = "README.md"
 license = { text = "MIT" }
@@ -28,7 +28,10 @@ classifiers = [
 ]
 keywords = ["etw", "windows", "tracing", "events", "monitoring", "logging"]
 
-dependencies = []
+dependencies = [
+    "click>=8.0",
+    "pyyaml>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -42,6 +45,12 @@ dev = [
 export = [
     "pandas>=2.0",
     "pyarrow>=14.0",
+]
+docs = [
+    "sphinx>=7.0",
+    "sphinx-rtd-theme>=2.0",
+    "sphinx-autodoc-typehints>=2.0",
+    "myst-parser>=3.0",
 ]
 
 [project.urls]

--- a/src/pyetwkit/cli.py
+++ b/src/pyetwkit/cli.py
@@ -1,0 +1,255 @@
+"""Command-line interface for PyETWkit.
+
+This module provides a CLI tool for monitoring ETW events from the command line.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+
+from pyetwkit import __version__
+
+
+@click.group()
+@click.version_option(version=__version__, prog_name="pyetwkit")
+def main() -> None:
+    """PyETWkit - High-performance ETW consumer for Python.
+
+    Monitor Windows ETW events from the command line.
+
+    Examples:
+
+        # List available providers
+        pyetwkit providers
+
+        # Search for providers
+        pyetwkit providers --search Kernel
+
+        # List available profiles
+        pyetwkit profiles
+
+        # Listen to events (requires admin)
+        pyetwkit listen Microsoft-Windows-Kernel-Process
+    """
+    pass
+
+
+@main.command()
+@click.option("--search", "-s", help="Search for providers by name")
+@click.option("--limit", "-n", default=50, help="Maximum number of providers to show")
+@click.option(
+    "--format", "-f", "output_format", type=click.Choice(["table", "json"]), default="table"
+)
+def providers(search: str | None, limit: int, output_format: str) -> None:
+    """List available ETW providers.
+
+    Shows registered ETW providers on the system. Use --search to filter
+    by name.
+
+    Examples:
+
+        pyetwkit providers
+        pyetwkit providers --search Kernel
+        pyetwkit providers --format json
+    """
+    try:
+        from pyetwkit._core import list_providers, search_providers
+    except ImportError:
+        click.echo("Error: Native extension not available", err=True)
+        sys.exit(1)
+
+    provider_list = search_providers(search) if search else list_providers()
+
+    # Limit results
+    provider_list = provider_list[:limit]
+
+    if output_format == "json":
+        data = [{"name": p.name, "guid": p.guid, "source": p.source} for p in provider_list]
+        click.echo(json.dumps(data, indent=2))
+    else:
+        click.echo(f"{'Name':<60} {'GUID':<38} Source")
+        click.echo("-" * 110)
+        for p in provider_list:
+            click.echo(f"{p.name[:59]:<60} {p.guid:<38} {p.source}")
+
+    if not search:
+        total = len(list_providers())
+        click.echo(f"\nShowing {len(provider_list)} of {total} providers")
+
+
+@main.command()
+@click.option(
+    "--format", "-f", "output_format", type=click.Choice(["table", "json"]), default="table"
+)
+def profiles(output_format: str) -> None:
+    """List available provider profiles.
+
+    Profiles are pre-configured sets of providers for common use cases
+    like audio monitoring, network analysis, etc.
+
+    Examples:
+
+        pyetwkit profiles
+        pyetwkit profiles --format json
+    """
+    from pyetwkit.profiles import list_profiles
+
+    profile_list = list_profiles()
+
+    if output_format == "json":
+        data = [
+            {
+                "name": p.name,
+                "description": p.description,
+                "providers": [pr.name for pr in p.providers],
+            }
+            for p in profile_list
+        ]
+        click.echo(json.dumps(data, indent=2))
+    else:
+        click.echo(f"{'Profile':<15} {'Description':<50} Providers")
+        click.echo("-" * 80)
+        for p in profile_list:
+            provider_count = len(p.providers)
+            click.echo(f"{p.name:<15} {p.description[:49]:<50} {provider_count}")
+
+
+@main.command()
+@click.argument("provider", required=False)
+@click.option("--profile", "-p", help="Use a provider profile")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["table", "json", "jsonl"]),
+    default="table",
+)
+@click.option("--output", "-o", type=click.Path(), help="Output file path")
+@click.option("--max-events", "-n", type=int, help="Maximum number of events to capture")
+@click.option(
+    "--level",
+    "-l",
+    type=click.Choice(["critical", "error", "warning", "info", "verbose"]),
+    default="info",
+)
+def listen(
+    provider: str | None,
+    profile: str | None,
+    output_format: str,
+    output: str | None,
+    max_events: int | None,
+    level: str,
+) -> None:
+    """Listen to ETW events from a provider or profile.
+
+    Requires administrator privileges to start ETW sessions.
+
+    Examples:
+
+        # Listen to a specific provider
+        pyetwkit listen Microsoft-Windows-Kernel-Process
+
+        # Use a profile
+        pyetwkit listen --profile audio
+
+        # Output to file
+        pyetwkit listen --profile network --output events.jsonl --format jsonl
+
+        # Limit events
+        pyetwkit listen Microsoft-Windows-DNS-Client --max-events 100
+    """
+    if not provider and not profile:
+        click.echo("Error: Please specify a provider or --profile", err=True)
+        click.echo("Usage: pyetwkit listen PROVIDER or pyetwkit listen --profile PROFILE", err=True)
+        sys.exit(1)
+
+    # Import here to avoid import errors when just showing help
+    try:
+        from pyetwkit._core import EtwProvider, EtwSession
+    except ImportError:
+        click.echo("Error: Native extension not available", err=True)
+        sys.exit(1)
+
+    # Get providers from profile or direct specification
+    providers_to_use = []
+    if profile:
+        from pyetwkit.profiles import get_profile
+
+        prof = get_profile(profile)
+        if prof is None:
+            click.echo(f"Error: Profile '{profile}' not found", err=True)
+            sys.exit(1)
+        for pc in prof.providers:
+            providers_to_use.append((pc.name, pc.guid or pc.name))
+    else:
+        providers_to_use.append((provider, provider))
+
+    click.echo(f"Starting ETW session with {len(providers_to_use)} provider(s)...")
+    click.echo("Press Ctrl+C to stop\n")
+
+    # Level mapping
+    level_map = {
+        "critical": 1,
+        "error": 2,
+        "warning": 3,
+        "info": 4,
+        "verbose": 5,
+    }
+
+    try:
+        session = EtwSession("PyETWkitCLI")
+
+        for name, guid_or_name in providers_to_use:
+            prov = EtwProvider(guid_or_name, name)
+            prov = prov.with_level(level_map.get(level, 4))
+            session.add_provider(prov)
+
+        session.start()
+
+        event_count = 0
+        output_file = None
+
+        try:
+            if output:
+                output_file = open(output, "w", encoding="utf-8")  # noqa: SIM115
+
+            while True:
+                if max_events and event_count >= max_events:
+                    break
+
+                event = session.next_event_timeout(1000)  # 1 second timeout
+                if event is None:
+                    continue
+
+                event_count += 1
+
+                # Format event
+                if output_format in ("json", "jsonl"):
+                    line = json.dumps(event.to_dict(), default=str)
+                else:
+                    line = f"[{event.timestamp}] {event.provider_name or event.provider_id} Event {event.event_id}"
+
+                if output_file:
+                    output_file.write(line + "\n")
+                    output_file.flush()
+                else:
+                    click.echo(line)
+
+        except KeyboardInterrupt:
+            click.echo(f"\nStopped. Captured {event_count} events.")
+        finally:
+            if output_file:
+                output_file.close()
+            session.stop()
+
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        click.echo("Note: ETW sessions require administrator privileges", err=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyetwkit/profiles.py
+++ b/src/pyetwkit/profiles.py
@@ -1,0 +1,286 @@
+"""Provider profiles for common use cases.
+
+This module provides pre-configured provider profiles for common ETW monitoring scenarios
+such as audio, network, GPU, and process monitoring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class ProviderConfig:
+    """Configuration for a single ETW provider within a profile."""
+
+    name: str
+    """Provider name or GUID."""
+
+    guid: str | None = None
+    """Provider GUID (optional if name is sufficient)."""
+
+    level: str | int = "verbose"
+    """Trace level: critical, error, warning, information, verbose, or 0-5."""
+
+    keywords: int | None = None
+    """Keywords bitmask for filtering events."""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProviderConfig:
+        """Create ProviderConfig from dictionary."""
+        return cls(
+            name=data.get("name", ""),
+            guid=data.get("guid"),
+            level=data.get("level", "verbose"),
+            keywords=data.get("keywords"),
+        )
+
+
+@dataclass
+class Profile:
+    """A provider profile containing multiple provider configurations."""
+
+    name: str
+    """Profile name."""
+
+    description: str = ""
+    """Profile description."""
+
+    providers: list[ProviderConfig] = field(default_factory=list)
+    """List of provider configurations."""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Profile:
+        """Create Profile from dictionary."""
+        providers = [
+            ProviderConfig.from_dict(p) if isinstance(p, dict) else p
+            for p in data.get("providers", [])
+        ]
+        return cls(
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            providers=providers,
+        )
+
+    @classmethod
+    def from_yaml(cls, yaml_str: str) -> Profile:
+        """Create Profile from YAML string."""
+        data = yaml.safe_load(yaml_str)
+        return cls.from_dict(data)
+
+
+# Built-in profiles
+_BUILTIN_PROFILES: dict[str, Profile] = {}
+
+
+def _init_builtin_profiles() -> None:
+    """Initialize built-in profiles."""
+    global _BUILTIN_PROFILES
+
+    # Audio profile
+    _BUILTIN_PROFILES["audio"] = Profile(
+        name="audio",
+        description="Audio-related providers (WASAPI, Media Foundation, Audio)",
+        providers=[
+            ProviderConfig(
+                name="Microsoft-Windows-Audio",
+                guid="ae4bd3be-f36f-45b6-8d21-bdd6fb832853",
+                level="verbose",
+            ),
+            ProviderConfig(
+                name="Microsoft-Windows-MediaFoundation-Platform",
+                guid="bc97b970-d001-482f-8745-b8d7d5759f99",
+                level="information",
+            ),
+            ProviderConfig(
+                name="Microsoft-Windows-MMCSS",
+                guid="36008301-e154-466c-acec-5f4cbd6b4694",
+                level="verbose",
+            ),
+        ],
+    )
+
+    # Network profile
+    _BUILTIN_PROFILES["network"] = Profile(
+        name="network",
+        description="Network-related providers (TCP/IP, DNS, NDIS)",
+        providers=[
+            ProviderConfig(
+                name="Microsoft-Windows-TCPIP",
+                guid="2f07e2ee-15db-40f1-90ef-9d7ba282188a",
+                level="information",
+            ),
+            ProviderConfig(
+                name="Microsoft-Windows-DNS-Client",
+                guid="1c95126e-7eea-49a9-a3fe-a378b03ddb4d",
+                level="information",
+            ),
+            ProviderConfig(
+                name="Microsoft-Windows-NDIS",
+                guid="cdead503-17f5-4a3e-b7ae-df8cc2902eb9",
+                level="information",
+            ),
+        ],
+    )
+
+    # GPU profile
+    _BUILTIN_PROFILES["gpu"] = Profile(
+        name="gpu",
+        description="GPU-related providers (DXGI, D3D, DWM)",
+        providers=[
+            ProviderConfig(
+                name="Microsoft-Windows-DXGI",
+                guid="ca11c036-0102-4a2d-a6ad-f03cfed5d3c9",
+                level="information",
+            ),
+            ProviderConfig(
+                name="Microsoft-Windows-D3D9",
+                guid="783aca0a-790e-4d7f-8451-aa850511c6b9",
+                level="information",
+            ),
+            ProviderConfig(
+                name="Microsoft-Windows-Dwm-Core",
+                guid="9e9bba3c-2e38-40cb-99f4-9e8281425164",
+                level="information",
+            ),
+        ],
+    )
+
+    # Process profile
+    _BUILTIN_PROFILES["process"] = Profile(
+        name="process",
+        description="Process-related providers (Kernel-Process)",
+        providers=[
+            ProviderConfig(
+                name="Microsoft-Windows-Kernel-Process",
+                guid="22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716",
+                level="information",
+                keywords=0x10,  # WINEVENT_KEYWORD_PROCESS
+            ),
+        ],
+    )
+
+    # File I/O profile
+    _BUILTIN_PROFILES["file"] = Profile(
+        name="file",
+        description="File I/O related providers",
+        providers=[
+            ProviderConfig(
+                name="Microsoft-Windows-Kernel-File",
+                guid="edd08927-9cc4-4e65-b970-c2560fb5c289",
+                level="information",
+            ),
+        ],
+    )
+
+    # Security profile
+    _BUILTIN_PROFILES["security"] = Profile(
+        name="security",
+        description="Security-related providers",
+        providers=[
+            ProviderConfig(
+                name="Microsoft-Windows-Security-Auditing",
+                guid="54849625-5478-4994-a5ba-3e3b0328c30d",
+                level="information",
+            ),
+        ],
+    )
+
+    # PowerShell profile
+    _BUILTIN_PROFILES["powershell"] = Profile(
+        name="powershell",
+        description="PowerShell-related providers",
+        providers=[
+            ProviderConfig(
+                name="Microsoft-Windows-PowerShell",
+                guid="a0c1853b-5c40-4b15-8766-3cf1c58f985a",
+                level="verbose",
+            ),
+        ],
+    )
+
+
+# Initialize built-in profiles
+_init_builtin_profiles()
+
+
+def get_profile(name: str) -> Profile | None:
+    """Get a profile by name.
+
+    Args:
+        name: Profile name (e.g., "audio", "network", "gpu")
+
+    Returns:
+        Profile if found, None otherwise
+
+    Example:
+        >>> from pyetwkit.profiles import get_profile
+        >>> profile = get_profile("audio")
+        >>> print(profile.description)
+    """
+    return _BUILTIN_PROFILES.get(name)
+
+
+def list_profiles() -> list[Profile]:
+    """List all available profiles.
+
+    Returns:
+        List of all registered profiles
+
+    Example:
+        >>> from pyetwkit.profiles import list_profiles
+        >>> for profile in list_profiles():
+        ...     print(f"{profile.name}: {profile.description}")
+    """
+    return list(_BUILTIN_PROFILES.values())
+
+
+def load_profile(path: str | Path) -> Profile:
+    """Load a profile from a YAML file.
+
+    Args:
+        path: Path to YAML file
+
+    Returns:
+        Loaded Profile
+
+    Example:
+        >>> from pyetwkit.profiles import load_profile
+        >>> profile = load_profile("my_profile.yaml")
+    """
+    path = Path(path)
+    yaml_content = path.read_text(encoding="utf-8")
+    profile = Profile.from_yaml(yaml_content)
+
+    # Register the loaded profile
+    _BUILTIN_PROFILES[profile.name] = profile
+
+    return profile
+
+
+def register_profile(profile: Profile) -> None:
+    """Register a custom profile.
+
+    Args:
+        profile: Profile to register
+
+    Example:
+        >>> from pyetwkit.profiles import Profile, register_profile
+        >>> profile = Profile(name="custom", providers=[...])
+        >>> register_profile(profile)
+    """
+    _BUILTIN_PROFILES[profile.name] = profile
+
+
+__all__ = [
+    "Profile",
+    "ProviderConfig",
+    "get_profile",
+    "list_profiles",
+    "load_profile",
+    "register_profile",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,153 @@
+"""Tests for CLI tool (v1.0.0 - #15)."""
+
+
+class TestCliModule:
+    """Tests for CLI module structure."""
+
+    def test_cli_module_exists(self) -> None:
+        """Test that pyetwkit.cli module exists."""
+        from pyetwkit import cli  # noqa: F401
+
+        assert True
+
+    def test_main_function_exists(self) -> None:
+        """Test that main function exists."""
+        from pyetwkit.cli import main
+
+        assert callable(main)
+
+
+class TestCliCommands:
+    """Tests for CLI commands."""
+
+    def test_cli_help(self) -> None:
+        """Test that --help works."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.output
+
+    def test_cli_version(self) -> None:
+        """Test that --version works."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+
+    def test_cli_providers_command(self) -> None:
+        """Test that providers command exists."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "--help"])
+        assert result.exit_code == 0
+
+    def test_cli_listen_command(self) -> None:
+        """Test that listen command exists."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["listen", "--help"])
+        assert result.exit_code == 0
+
+    def test_cli_profiles_command(self) -> None:
+        """Test that profiles command exists."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["profiles", "--help"])
+        assert result.exit_code == 0
+
+
+class TestProvidersCommand:
+    """Tests for providers command."""
+
+    def test_providers_list(self) -> None:
+        """Test listing providers."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers"])
+        assert result.exit_code == 0
+        # Should list some providers
+        assert "Microsoft" in result.output or "Provider" in result.output
+
+    def test_providers_search(self) -> None:
+        """Test searching providers."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["providers", "--search", "Kernel"])
+        assert result.exit_code == 0
+
+
+class TestProfilesCommand:
+    """Tests for profiles command."""
+
+    def test_profiles_list(self) -> None:
+        """Test listing profiles."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["profiles"])
+        assert result.exit_code == 0
+        # Should show built-in profiles
+        assert "audio" in result.output.lower() or "network" in result.output.lower()
+
+
+class TestListenCommand:
+    """Tests for listen command."""
+
+    def test_listen_requires_provider_or_profile(self) -> None:
+        """Test that listen requires provider or profile."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["listen"])
+        # Should fail or show error without provider/profile
+        assert (
+            result.exit_code != 0
+            or "error" in result.output.lower()
+            or "usage" in result.output.lower()
+        )
+
+    def test_listen_format_option(self) -> None:
+        """Test that listen has format option."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["listen", "--help"])
+        assert "--format" in result.output or "-f" in result.output
+
+    def test_listen_output_option(self) -> None:
+        """Test that listen has output option."""
+        from click.testing import CliRunner
+
+        from pyetwkit.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["listen", "--help"])
+        assert "--output" in result.output or "-o" in result.output

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,182 @@
+"""Tests for provider profiles (v1.0.0 - #16, #34)."""
+
+from pathlib import Path
+
+
+class TestProfileModule:
+    """Tests for profiles module structure."""
+
+    def test_profiles_module_exists(self) -> None:
+        """Test that pyetwkit.profiles module exists."""
+        from pyetwkit import profiles  # noqa: F401
+
+        assert True
+
+    def test_load_profile_function_exists(self) -> None:
+        """Test that load_profile function exists."""
+        from pyetwkit.profiles import load_profile
+
+        assert callable(load_profile)
+
+    def test_get_profile_function_exists(self) -> None:
+        """Test that get_profile function exists."""
+        from pyetwkit.profiles import get_profile
+
+        assert callable(get_profile)
+
+    def test_list_profiles_function_exists(self) -> None:
+        """Test that list_profiles function exists."""
+        from pyetwkit.profiles import list_profiles
+
+        assert callable(list_profiles)
+
+
+class TestBuiltinProfiles:
+    """Tests for built-in provider profiles."""
+
+    def test_audio_profile_exists(self) -> None:
+        """Test that audio profile is available."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("audio")
+        assert profile is not None
+        assert profile.name == "audio"
+
+    def test_network_profile_exists(self) -> None:
+        """Test that network profile is available."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("network")
+        assert profile is not None
+        assert profile.name == "network"
+
+    def test_gpu_profile_exists(self) -> None:
+        """Test that gpu profile is available."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("gpu")
+        assert profile is not None
+        assert profile.name == "gpu"
+
+    def test_process_profile_exists(self) -> None:
+        """Test that process profile is available."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("process")
+        assert profile is not None
+        assert profile.name == "process"
+
+    def test_list_profiles_returns_builtin(self) -> None:
+        """Test that list_profiles returns built-in profiles."""
+        from pyetwkit.profiles import list_profiles
+
+        profiles = list_profiles()
+        assert len(profiles) >= 4
+        names = [p.name for p in profiles]
+        assert "audio" in names
+        assert "network" in names
+
+
+class TestProfileStructure:
+    """Tests for Profile data structure."""
+
+    def test_profile_has_name(self) -> None:
+        """Test that Profile has name attribute."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("audio")
+        assert hasattr(profile, "name")
+        assert isinstance(profile.name, str)
+
+    def test_profile_has_description(self) -> None:
+        """Test that Profile has description attribute."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("audio")
+        assert hasattr(profile, "description")
+
+    def test_profile_has_providers(self) -> None:
+        """Test that Profile has providers list."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("audio")
+        assert hasattr(profile, "providers")
+        assert isinstance(profile.providers, list)
+        assert len(profile.providers) > 0
+
+    def test_provider_entry_has_required_fields(self) -> None:
+        """Test that provider entry has required fields."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("audio")
+        provider = profile.providers[0]
+        # Should have name or guid
+        assert hasattr(provider, "name") or hasattr(provider, "guid")
+
+
+class TestCustomProfiles:
+    """Tests for custom profile loading."""
+
+    def test_load_profile_from_yaml(self, tmp_path: Path) -> None:
+        """Test loading profile from YAML file."""
+        from pyetwkit.profiles import load_profile
+
+        yaml_content = """
+name: test_profile
+description: Test profile for unit tests
+providers:
+  - name: Microsoft-Windows-Kernel-Process
+    level: verbose
+"""
+        yaml_file = tmp_path / "test_profile.yaml"
+        yaml_file.write_text(yaml_content)
+
+        profile = load_profile(str(yaml_file))
+        assert profile.name == "test_profile"
+        assert len(profile.providers) == 1
+
+    def test_load_profile_from_dict(self) -> None:
+        """Test loading profile from dictionary."""
+        from pyetwkit.profiles import Profile
+
+        data = {
+            "name": "dict_profile",
+            "description": "Profile from dict",
+            "providers": [{"name": "Microsoft-Windows-Kernel-Process", "level": "verbose"}],
+        }
+
+        profile = Profile.from_dict(data)
+        assert profile.name == "dict_profile"
+
+    def test_get_nonexistent_profile_returns_none(self) -> None:
+        """Test that getting non-existent profile returns None."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("nonexistent_profile_xyz")
+        assert profile is None
+
+
+class TestProfileProviderConfig:
+    """Tests for provider configuration in profiles."""
+
+    def test_provider_config_has_level(self) -> None:
+        """Test that provider config can have level."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("audio")
+        provider = profile.providers[0]
+        # Level should be accessible
+        assert (
+            hasattr(provider, "level")
+            or provider.level is None
+            or isinstance(provider.level, (str, int))
+        )
+
+    def test_provider_config_has_keywords(self) -> None:
+        """Test that provider config can have keywords."""
+        from pyetwkit.profiles import get_profile
+
+        profile = get_profile("process")
+        provider = profile.providers[0]
+        # Keywords should be accessible (may be None)
+        assert hasattr(provider, "keywords")


### PR DESCRIPTION
## Summary

This PR implements the v1.0.0 milestone features:

### #15 CLI Live Viewer
- `pyetwkit providers` - List/search ETW providers
- `pyetwkit profiles` - List available profiles
- `pyetwkit listen` - Monitor ETW events with format/output options

### #16/#34 Provider Profiles
Built-in profiles for common use cases:
- `audio` - WASAPI, Media Foundation, MMCSS
- `network` - TCP/IP, DNS, NDIS
- `gpu` - DXGI, D3D, DWM
- `process` - Kernel-Process
- `file` - Kernel-File
- `security` - Security-Auditing
- `powershell` - PowerShell

Custom profiles via YAML:
```yaml
name: my_profile
providers:
  - name: Microsoft-Windows-DNS-Client
    level: verbose
```

### #20 API Documentation
- Sphinx project with autodoc
- Quick start guide, tutorial
- API reference for all modules
- ETW basics guide

## Test Results
- 117 passed, 21 skipped (admin required)

## CLI Usage Examples
```bash
# List providers
pyetwkit providers --search Kernel

# List profiles
pyetwkit profiles

# Monitor events (admin required)
pyetwkit listen --profile network --format json
```

## Test plan
- [x] All existing tests pass (117 passed)
- [x] New profile tests pass (18 tests)
- [x] New CLI tests pass (13 tests)
- [x] Black/ruff lint passes
- [x] Sphinx docs build successfully

Closes #15, #16, #20, #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)