### PR TITLE
fix(ci): Fix rust-toolchain action name in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install maturin
         run: pip install maturin


### PR DESCRIPTION
## Summary
Fix typo in release.yml:  -> 

## Problem
Release workflow was failing with:


## Solution
The correct action name is , not .

🤖 Generated with [Claude Code](https://claude.com/claude-code)