### PR TITLE
docs: Add v1.1 issue links to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ Windows ETW subsystem
 ### Planned
 
 #### v1.1 - Enhanced Core
-- [ ] Async streaming API
-- [ ] Manifest-based typed events
-- [ ] Real-time event filtering callbacks
+- [ ] [Async streaming API](https://github.com/m96-chan/PyETWkit/issues/54)
+- [ ] [Manifest-based typed events](https://github.com/m96-chan/PyETWkit/issues/55)
+- [ ] [Real-time event filtering callbacks](https://github.com/m96-chan/PyETWkit/issues/56)
 
 #### v2.0 - Enterprise Features
 - [ ] [Multi-session / Multi-provider concurrent subscription](https://github.com/m96-chan/PyETWkit/issues/48)


### PR DESCRIPTION
## Summary

Add GitHub issue links to v1.1 roadmap items in README.

## Changes

Link v1.1 roadmap items to their GitHub issues:
- #54 Async streaming API
- #55 Manifest-based typed events
- #56 Real-time event filtering callbacks

## Test plan

- [x] Verify links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)